### PR TITLE
Update index page loading spinner and add ?guildId search parameter redirection

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,21 @@
     <script src="https://media.arion2000.xyz/cdn/js/redirect.min.js"></script>
 </head>
 
-<body onload="onLoad('/api/discord')">
+<body onload="getUrlParams()">
     <h3>Weiterleitung...</h3>
+
+    <script>
+        function getUrlParams() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const guildId = urlParams.get('guildId');
+
+            if (guildId == '' || guildId == undefined || guildId == null) {
+                onLoad('/api/discord');
+            } else {
+                onLoad(`/api/discord/?guildId=${guildId}`);
+            }
+        }
+    </script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     </style>
 </head>
 
-<body onload="">
+<body onload="getUrlParams()">
     <div class="loader">
         <div></div>
         <div></div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <title>Weiterleitung - arion2000.xyz API</title>
 
     <style>
-        /* Gesamtseitenstil */
         body, html {
             margin: 0;
             padding: 0;
@@ -19,14 +18,12 @@
             overflow: hidden;
         }
 
-        /* Wrapper für die Ladeanimation */
         .loader {
             position: relative;
             width: 32px;
             height: 32px;
         }
 
-        /* Stil für die Quadrate */
         .loader div {
             position: absolute;
             width: 10px;
@@ -35,20 +32,17 @@
             animation: wanderingCubes 1.8s ease-in-out infinite;
         }
 
-        /* Erstes Quadrat, Animation startet ohne Verzögerung */
         .loader div:nth-child(1) {
             top: 0;
             left: 0;
         }
 
-        /* Zweites Quadrat mit Verzögerung */
         .loader div:nth-child(2) {
             top: 0;
             left: 0;
             animation-delay: -0.9s;
         }
 
-        /* Keyframes für die kreisförmige Bewegung */
         @keyframes wanderingCubes {
             0% {
                 transform: translate(0, 0) rotate(0deg) scale(1);
@@ -70,7 +64,6 @@
 </head>
 
 <body onload="">
-    <!-- Ladeanimation -->
     <div class="loader">
         <div></div>
         <div></div>

--- a/index.html
+++ b/index.html
@@ -4,14 +4,72 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>arion2000.xyz API</title>
-    <link rel="stylesheet" href="https://media.arion2000.xyz/cdn/css/redirect.min.css">
-    <script src="https://media.arion2000.xyz/cdn/js/redirect.min.js"></script>
+    <title>Weiterleitung - arion2000.xyz API</title>
+
+    <style>
+        /* Gesamtseitenstil */
+        body, html {
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #1d232e;
+            overflow: hidden;
+        }
+
+        /* Wrapper für die Ladeanimation */
+        .loader {
+            position: relative;
+            width: 50px;
+            height: 50px;
+        }
+
+        /* Grundstil für die Quadrate */
+        .loader div {
+            position: absolute;
+            width: 10px;
+            height: 10px;
+            background-color: #7984f5;
+            animation: orbit 1.5s linear infinite;
+        }
+
+        /* Platzierung und Verzögerung für das erste Quadrat */
+        .loader div:nth-child(1) {
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            animation-delay: -0.75s;
+        }
+
+        /* Platzierung für das zweite Quadrat */
+        .loader div:nth-child(2) {
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+        }
+
+        /* Animation für die kreisförmige Bewegung */
+        @keyframes orbit {
+            0% {
+                transform: translateX(-50%) rotate(0deg) translate(20px) rotate(0deg);
+            }
+            100% {
+                transform: translateX(-50%) rotate(360deg) translate(20px) rotate(-360deg);
+            }
+        }
+    </style>
 </head>
 
 <body onload="getUrlParams()">
-    <h3>Weiterleitung...</h3>
+    <!-- Ladeanimation -->
+    <div class="loader">
+        <div></div>
+        <div></div>
+    </div>
 
+    <script src="https://media.arion2000.xyz/cdn/js/redirect.min.js"></script>
     <script>
         function getUrlParams() {
             const urlParams = new URLSearchParams(window.location.search);

--- a/index.html
+++ b/index.html
@@ -22,47 +22,54 @@
         /* Wrapper für die Ladeanimation */
         .loader {
             position: relative;
-            width: 50px;
-            height: 50px;
+            width: 32px;
+            height: 32px;
         }
 
-        /* Grundstil für die Quadrate */
+        /* Stil für die Quadrate */
         .loader div {
             position: absolute;
             width: 10px;
             height: 10px;
             background-color: #7984f5;
-            animation: orbit 1.5s linear infinite;
+            animation: wanderingCubes 1.8s ease-in-out infinite;
         }
 
-        /* Platzierung und Verzögerung für das erste Quadrat */
+        /* Erstes Quadrat, Animation startet ohne Verzögerung */
         .loader div:nth-child(1) {
             top: 0;
-            left: 50%;
-            transform: translateX(-50%);
-            animation-delay: -0.75s;
+            left: 0;
         }
 
-        /* Platzierung für das zweite Quadrat */
+        /* Zweites Quadrat mit Verzögerung */
         .loader div:nth-child(2) {
-            bottom: 0;
-            left: 50%;
-            transform: translateX(-50%);
+            top: 0;
+            left: 0;
+            animation-delay: -0.9s;
         }
 
-        /* Animation für die kreisförmige Bewegung */
-        @keyframes orbit {
+        /* Keyframes für die kreisförmige Bewegung */
+        @keyframes wanderingCubes {
             0% {
-                transform: translateX(-50%) rotate(0deg) translate(20px) rotate(0deg);
+                transform: translate(0, 0) rotate(0deg) scale(1);
+            }
+            25% {
+                transform: translate(22px, 0) rotate(-90deg) scale(0.5);
+            }
+            50% {
+                transform: translate(22px, 22px) rotate(-180deg) scale(1);
+            }
+            75% {
+                transform: translate(0, 22px) rotate(-270deg) scale(0.5);
             }
             100% {
-                transform: translateX(-50%) rotate(360deg) translate(20px) rotate(-360deg);
+                transform: translate(0, 0) rotate(-360deg) scale(1);
             }
         }
     </style>
 </head>
 
-<body onload="getUrlParams()">
+<body onload="">
     <!-- Ladeanimation -->
     <div class="loader">
         <div></div>


### PR DESCRIPTION
The index page loading spinner is now similar to the original one from discord. Also the `?guildId=...` search parameter can now be used on the index page and will be redirected to `/api/discrd?guildId=...` for shorter urls.